### PR TITLE
[um][docs] Update mmp ws channel to correct name

### DIFF
--- a/python/api/drfqv2/auto-market-services/helpers/processors.py
+++ b/python/api/drfqv2/auto-market-services/helpers/processors.py
@@ -38,7 +38,7 @@ class ParadigmWSMessageProcessor:
 
             ws_channel: str = msg['params']['channel']
 
-            if ws_channel == 'mmp':
+            if ws_channel == 'market_maker_protection':
                 await self.managed_mmp.ingest_ws_message(
                     message=msg
                     )

--- a/python/api/drfqv2/auto-market-services/market-maker.py
+++ b/python/api/drfqv2/auto-market-services/market-maker.py
@@ -124,7 +124,7 @@ class main:
             channels_to_subscribe_on_start=[
                 'rfqs',
                 'orders',
-                'mmp'
+                'market_maker_protection'
                 ]
             )
 


### PR DESCRIPTION
A user reached out and indicated the they weren't able to connect to
the `mmp` channel. 

Since this has been renamed to `market_maker_protection`, 
update our examples as well.
